### PR TITLE
Tweak CSS, change em to mark

### DIFF
--- a/src/kibana/components/highlight/highlight.js
+++ b/src/kibana/components/highlight/highlight.js
@@ -21,8 +21,8 @@ define(function (require) {
 
         // Replace all highlight tags with proper html tags
         var tagged = section
-          .split(highlightTags.pre).join('<em>')
-          .split(highlightTags.post).join('</em>');
+          .split(highlightTags.pre).join('<mark>')
+          .split(highlightTags.post).join('</mark>');
 
         // Replace all instances of the untagged string with the properly tagged string
         formatted = formatted.split(untagged).join(tagged);

--- a/src/kibana/styles/_table.less
+++ b/src/kibana/styles/_table.less
@@ -12,36 +12,26 @@ kbn-table,tbody[kbn-rows] {
     }
   }
 
-  tr.even td {
-    background-color: #f1f1f1;
-  }
-
   td.numeric-value {
     text-align: right;
     padding-right: 15px;
   }
 
   dl.source {
-    line-height: 2em;
     margin-bottom: 0;
+    line-height: 2em;
 
     dt {
       display: inline;
-      background: #ECECEC;
-      padding: 0.15em 0.2em 0.15em 0.7em;
-      margin-right: 0.3em;
-      font-weight: bold;
-      color: #5F5F5F;
+      background: @gray-lighter;
+      padding: @padding-xs-vertical @padding-xs-horizontal;
+      margin-right: @padding-xs-horizontal;
       font-family: monospace;
     }
 
     dd {
       display: inline;
-      margin-right: 0.75em;
     }
   }
 
-  td em {
-    background-color: yellow;
-  }
 }

--- a/test/unit/specs/components/highlight/highlight.js
+++ b/test/unit/specs/components/highlight/highlight.js
@@ -28,8 +28,8 @@ define(function (require) {
         tags.pre + 'hamburger' + tags.post + ' alcatra cupim. Salami capicola boudin pork belly shank picanha.'
       ];
       var result = filter(text, highlights);
-      expect(result.indexOf('<em>hamburger</em>')).to.be.greaterThan(-1);
-      expect(result.split('<em>hamburger</em>').length).to.be(text.split('hamburger').length);
+      expect(result.indexOf('<mark>hamburger</mark>')).to.be.greaterThan(-1);
+      expect(result.split('<mark>hamburger</mark>').length).to.be(text.split('hamburger').length);
     });
 
     it('should highlight multiple results', function () {
@@ -39,8 +39,8 @@ define(function (require) {
         'Chicken' + tags.post + ' cow beef picanha. Picanha'
       ];
       var result = filter(text, highlights);
-      expect(result.indexOf('<em>Chicken</em>')).to.be.greaterThan(-1);
-      expect(result.split('<em>Chicken</em>').length).to.be(text.split('Chicken').length);
+      expect(result.indexOf('<mark>Chicken</mark>')).to.be.greaterThan(-1);
+      expect(result.split('<mark>Chicken</mark>').length).to.be(text.split('Chicken').length);
     });
 
     it('should highlight multiple hits in a result', function () {
@@ -55,8 +55,8 @@ define(function (require) {
           'belly shank picanha.'
       ];
       var result = filter(text, highlights);
-      expect(result.indexOf('<em>pork</em>')).to.be.greaterThan(-1);
-      expect(result.split('<em>pork</em>').length).to.be(text.split('pork').length);
+      expect(result.indexOf('<mark>pork</mark>')).to.be.greaterThan(-1);
+      expect(result.split('<mark>pork</mark>').length).to.be(text.split('pork').length);
     });
 
     it('should accept an object and return a string containing its properties', function () {


### PR DESCRIPTION
I switched the `em` to `mark` since that tag is styled as a highlight by default and works with our bootstrap stuff. I also changed some small CSS items to use the bootstrap variables.
