### PR TITLE
display info about missing object

### DIFF
--- a/src/kibana/plugins/dashboard/components/panel/lib/search.js
+++ b/src/kibana/plugins/dashboard/components/panel/lib/search.js
@@ -17,7 +17,7 @@ define(function (require) {
           return {
             savedObj: savedSearch,
             panel: panel,
-            edit: savedSearches.urlFor(panel.id)
+            editUrl: savedSearches.urlFor(panel.id)
           };
         });
     };

--- a/src/kibana/plugins/dashboard/components/panel/lib/search.js
+++ b/src/kibana/plugins/dashboard/components/panel/lib/search.js
@@ -17,7 +17,7 @@ define(function (require) {
           return {
             savedObj: savedSearch,
             panel: panel,
-            edit: '#discover'
+            edit: savedSearches.urlFor(panel.id)
           };
         });
     };

--- a/src/kibana/plugins/dashboard/components/panel/lib/visualization.js
+++ b/src/kibana/plugins/dashboard/components/panel/lib/visualization.js
@@ -13,7 +13,7 @@ define(function (require) {
           return {
             savedObj: savedVis,
             panel: panel,
-            edit: savedVisualizations.urlFor(panel.id)
+            editUrl: savedVisualizations.urlFor(panel.id)
           };
         });
     };

--- a/src/kibana/plugins/dashboard/components/panel/lib/visualization.js
+++ b/src/kibana/plugins/dashboard/components/panel/lib/visualization.js
@@ -13,7 +13,7 @@ define(function (require) {
           return {
             savedObj: savedVis,
             panel: panel,
-            edit: '#visualize/edit'
+            edit: savedVisualizations.urlFor(panel.id)
           };
         });
     };

--- a/src/kibana/plugins/dashboard/components/panel/panel.html
+++ b/src/kibana/plugins/dashboard/components/panel/panel.html
@@ -2,8 +2,12 @@
   <div class="panel-heading">
     <span class="panel-title">{{savedObj.title}}</span>
     <div class="btn-group">
-      <a aria-label="Edit" ng-show="!appEmbedded && edit" ng-href="{{edit}}/{{panel.id | uriescape}}"><i aria-hidden="true" class="fa fa-pencil"></i></a>
-      <a aria-label="Remove" ng-show="!appEmbedded" ng-click="remove()"><i aria-hidden="true" class="fa fa-times"></i></a>
+      <a aria-label="Edit" ng-show="!appEmbedded && editUrl" ng-href="{{editUrl}}">
+        <i aria-hidden="true" class="fa fa-pencil"></i>
+      </a>
+      <a aria-label="Remove" ng-show="!appEmbedded" ng-click="remove()">
+        <i aria-hidden="true" class="fa fa-times"></i>
+      </a>
     </div>
     <div class="clearfix"></div>
   </div>

--- a/src/kibana/plugins/dashboard/components/panel/panel.js
+++ b/src/kibana/plugins/dashboard/components/panel/panel.js
@@ -37,7 +37,7 @@ define(function (require) {
           loadPanel($scope.panel, $scope).then(function (panelConfig) {
             // These could be done in loadPanel, putting them here to make them more explicit
             $scope.savedObj = panelConfig.savedObj;
-            $scope.edit = panelConfig.edit;
+            $scope.editUrl = panelConfig.editUrl;
             $scope.$on('$destroy', panelConfig.savedObj.destroy);
 
             $scope.filter = function (field, value, operator) {
@@ -50,11 +50,15 @@ define(function (require) {
             // If the savedObjectType matches the panel type, this means the object itself has been deleted,
             // so we shouldn't even have an edit link. If they don't match, it means something else is wrong
             // with the object (but the object still exists), so we link to the object editor instead.
-            var objectHasBeenDeleted = e.savedObjectType === $scope.panel.type;
-            if (!objectHasBeenDeleted) {
-              var service = _.find(services, {type: $scope.panel.type});
-              $scope.edit = '#settings/objects/' + (service && service.name);
-            }
+            var objectItselfDeleted = e.savedObjectType === $scope.panel.type;
+            if (objectItselfDeleted) return;
+
+            var type = $scope.panel.type;
+            var id = $scope.panel.id;
+            var service = _.find(services, { type: type });
+            if (!service) return;
+
+            $scope.editUrl = '#settings/objects/' + service.name + '/' + id + '?notFound=' + e.savedObjectType;
           });
 
         });


### PR DESCRIPTION
With these changes
 1. panel loaders define the complete url (required for 2)
 2. the error handler now redirects to the saved object editor with the `?notFound=..` query string so that a message can be displayed to help the user

![image](https://cloud.githubusercontent.com/assets/1329312/8170256/3d42b5f8-1364-11e5-8f7d-66418cc9d491.png)
