### PR TITLE
Search session telemetry improvements

### DIFF
--- a/src/plugins/data/public/public.api.md
+++ b/src/plugins/data/public/public.api.md
@@ -2466,7 +2466,7 @@ export interface SearchUsageCollector {
     // (undocumented)
     trackSessionExtended: () => Promise<void>;
     // (undocumented)
-    trackSessionIndicatorTourDisabled: () => Promise<void>;
+    trackSessionIndicatorSaveDisabled: () => Promise<void>;
     // (undocumented)
     trackSessionIndicatorTourLoading: () => Promise<void>;
     // (undocumented)

--- a/src/plugins/data/public/search/collectors/create_usage_collector.ts
+++ b/src/plugins/data/public/search/collectors/create_usage_collector.ts
@@ -38,9 +38,9 @@ export const createUsageCollector = (
       METRIC_TYPE.LOADED,
       SEARCH_EVENT_TYPE.SESSION_INDICATOR_TOUR_RESTORED
     ),
-    trackSessionIndicatorTourDisabled: getCollector(
+    trackSessionIndicatorSaveDisabled: getCollector(
       METRIC_TYPE.LOADED,
-      SEARCH_EVENT_TYPE.SESSION_INDICATOR_TOUR_DISABLED
+      SEARCH_EVENT_TYPE.SESSION_INDICATOR_SAVE_DISABLED
     ),
     trackSessionSentToBackground: getCollector(
       METRIC_TYPE.CLICK,

--- a/src/plugins/data/public/search/collectors/mocks.ts
+++ b/src/plugins/data/public/search/collectors/mocks.ts
@@ -13,7 +13,7 @@ export function createSearchUsageCollectorMock(): jest.Mocked<SearchUsageCollect
     trackQueryTimedOut: jest.fn(),
     trackSessionIndicatorTourLoading: jest.fn(),
     trackSessionIndicatorTourRestored: jest.fn(),
-    trackSessionIndicatorTourDisabled: jest.fn(),
+    trackSessionIndicatorSaveDisabled: jest.fn(),
     trackSessionSentToBackground: jest.fn(),
     trackSessionSavedResults: jest.fn(),
     trackSessionViewRestored: jest.fn(),

--- a/src/plugins/data/public/search/collectors/types.ts
+++ b/src/plugins/data/public/search/collectors/types.ts
@@ -25,7 +25,7 @@ export enum SEARCH_EVENT_TYPE {
   /**
    * The session indicator was disabled because of a completion timeout
    */
-  SESSION_INDICATOR_TOUR_DISABLED = 'sessionIndicatorTourDisabled',
+  SESSION_INDICATOR_SAVE_DISABLED = 'sessionIndicatorSaveDisabled',
   /**
    * The user clicked to continue a session in the background (prior to results completing)
    */
@@ -75,7 +75,7 @@ export interface SearchUsageCollector {
   trackQueryTimedOut: () => Promise<void>;
   trackSessionIndicatorTourLoading: () => Promise<void>;
   trackSessionIndicatorTourRestored: () => Promise<void>;
-  trackSessionIndicatorTourDisabled: () => Promise<void>;
+  trackSessionIndicatorSaveDisabled: () => Promise<void>;
   trackSessionSentToBackground: () => Promise<void>;
   trackSessionSavedResults: () => Promise<void>;
   trackSessionViewRestored: () => Promise<void>;

--- a/x-pack/plugins/data_enhanced/public/search/ui/connected_search_session_indicator/connected_search_session_indicator.tsx
+++ b/x-pack/plugins/data_enhanced/public/search/ui/connected_search_session_indicator/connected_search_session_indicator.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { debounce, distinctUntilChanged, map, mapTo, switchMap, tap } from 'rxjs/operators';
 import { merge, of, timer } from 'rxjs';
 import useObservable from 'react-use/lib/useObservable';
@@ -14,8 +14,8 @@ import { SearchSessionIndicator, SearchSessionIndicatorRef } from '../search_ses
 import {
   ISessionService,
   SearchSessionState,
-  SearchUsageCollector,
   TimefilterContract,
+  SearchUsageCollector,
 } from '../../../../../../../src/plugins/data/public';
 import { RedirectAppLinks } from '../../../../../../../src/plugins/kibana_react/public';
 import { ApplicationStart } from '../../../../../../../src/core/public';
@@ -60,7 +60,7 @@ export const createConnectedSearchSessionIndicator = ({
     ),
     distinctUntilChanged(),
     tap((value) => {
-      if (value) usageCollector?.trackSessionIndicatorTourDisabled();
+      if (value) usageCollector?.trackSessionIndicatorSaveDisabled();
     })
   );
 
@@ -163,6 +163,12 @@ export const createConnectedSearchSessionIndicator = ({
     const onViewSearchSessions = useCallback(() => {
       usageCollector?.trackViewSessionsList();
     }, []);
+
+    useEffect(() => {
+      if (state === SearchSessionState.Restored) {
+        usageCollector?.trackSessionIsRestored();
+      }
+    }, [state]);
 
     if (!sessionService.isSessionStorageReady()) return null;
     return (


### PR DESCRIPTION
## Summary

Improvements to https://github.com/elastic/kibana/pull/89950

- Move `usageCollector?.trackSessionIsRestored();` outside of tour
- Rename `sessionIndicatorTourDisabled` -> `sessionIndicatorSaveDisabled`
- Make sure `trackSessionIndicatorTourLoading` and `trackSessionIndicatorTourRestored` are called only once per session. 
- Add unit tests


