### PR TITLE
Unified Doc Viewer push flyout touchups

### DIFF
--- a/src/plugins/discover/public/components/discover_grid_flyout/discover_grid_flyout.tsx
+++ b/src/plugins/discover/public/components/discover_grid_flyout/discover_grid_flyout.tsx
@@ -25,6 +25,7 @@ import {
   keys,
   EuiButtonEmpty,
   useEuiTheme,
+  useIsWithinMinBreakpoint,
 } from '@elastic/eui';
 import type { Filter, Query, AggregateQuery } from '@kbn/es-query';
 import type { DataTableRecord } from '@kbn/discover-utils/types';
@@ -82,7 +83,7 @@ export function DiscoverGridFlyout({
   const services = useDiscoverServices();
   const flyoutCustomization = useDiscoverCustomization('flyout');
   const { euiTheme } = useEuiTheme();
-
+  const isXlScreen = useIsWithinMinBreakpoint('xl');
   const defaultWidth = flyoutCustomization?.size ?? 540; // Give enough room to search bar to not wrap
   const [flyoutWidth, setFlyoutWidth] = useLocalStorage(FLYOUT_WIDTH_KEY, defaultWidth);
   const minWidth = euiTheme.base * 24;
@@ -230,6 +231,9 @@ export function DiscoverGridFlyout({
         minWidth={minWidth}
         maxWidth={maxWidth}
         onResize={setFlyoutWidth}
+        css={{
+          maxWidth: `${isXlScreen ? `calc(100vw - ${defaultWidth}px)` : '90vw'} !important`,
+        }}
       >
         <EuiFlyoutHeader hasBorder>
           <EuiFlexGroup
@@ -274,15 +278,11 @@ export function DiscoverGridFlyout({
         </EuiFlyoutHeader>
         <EuiFlyoutBody>{bodyContent}</EuiFlyoutBody>
         <EuiFlyoutFooter>
-          <EuiFlexGroup>
-            <EuiFlexItem grow={false}>
-              <EuiButtonEmpty iconType="cross" onClick={onClose} flush="left">
-                {i18n.translate('discover.grid.flyout.close', {
-                  defaultMessage: 'Close',
-                })}
-              </EuiButtonEmpty>
-            </EuiFlexItem>
-          </EuiFlexGroup>
+          <EuiButtonEmpty iconType="cross" onClick={onClose} flush="left">
+            {i18n.translate('discover.grid.flyout.close', {
+              defaultMessage: 'Close',
+            })}
+          </EuiButtonEmpty>
         </EuiFlyoutFooter>
       </EuiFlyoutResizable>
     </EuiPortal>

--- a/src/plugins/discover/public/components/discover_grid_flyout/discover_grid_flyout_actions.tsx
+++ b/src/plugins/discover/public/components/discover_grid_flyout/discover_grid_flyout_actions.tsx
@@ -41,15 +41,13 @@ export function DiscoverGridFlyoutActions({ flyoutActions }: DiscoverGridFlyoutA
   const isMobileScreen = useIsWithinBreakpoints(['xs', 's']);
   const isLargeScreen = dimensions?.width ? dimensions.width > euiTheme.base * 30 : false;
   return (
-    <EuiFlexGroup ref={setRef}>
-      <EuiFlexItem>
-        <FlyoutActions
-          flyoutActions={flyoutActions}
-          isMobileScreen={isMobileScreen}
-          isLargeScreen={isLargeScreen}
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
+    <div ref={setRef}>
+      <FlyoutActions
+        flyoutActions={flyoutActions}
+        isMobileScreen={isMobileScreen}
+        isLargeScreen={isLargeScreen}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

This PR includes a few minor touchups for the Unified Doc Viewer push flyout.

I noticed that when the window is slightly smaller, but not small enough to switch to the overlay flyout, expanding the push flyout can cause the Discover layout to become very squished and start breaking:

https://github.com/lukasolson/kibana/assets/25592674/12d1009f-1a05-472a-b3ac-7fdd7042aa0d

I also found that when the push flyout is expanded and I resized the screen, it would overflow the window when I resized it small enough that the flyout switched to an overlay. TBH this feels like an EUI bug to me, but I think we can work around it for now and file an issue to see if EUI is willing to change the behaviour:

https://github.com/lukasolson/kibana/assets/25592674/f7b00b93-cae8-4995-a3a8-5c23dd3957bb

IMO the right longer term solution to the layout squishing issue is probably to do similar to what we've done with the flyout table and actions, and make the layout responsive based on container size instead of window size, but this would involve a number of changes across Discover and Unified Search, so probably best to save that for a followup. In the meantime, when the screen is large enough for the push flyout, I added a max width to the flyout that leaves enough room that the Discover layout doesn't break too much. Similarly, we can address the flyout overflow issue by applying a max width to the flyout when in overlay mode so it can take up most but not all of the available screen space (same approach EUI uses for the flyout on mobile):

https://github.com/lukasolson/kibana/assets/25592674/d8f23fb1-4534-46a6-ab42-41d19b4859cd

The other thing I noticed was that when in mobile mode, the actions popover isn't aligned with the actual button because of the flex group/item around it. The close button also becomes centered within the flyout footer due to the flex group/item around it:
<img width="398" alt="mobile" src="https://github.com/lukasolson/kibana/assets/25592674/7a18556a-75d6-4258-9497-3c6a4d71de79">

I addressed the popover issue by just switching the flex group to a `div`, which fixes the alignment and preserves the responsiveness. For the close button, it looks like we can just drop the flex group entirely and it will remain aligned to the left:
<img width="396" alt="mobile_fixed" src="https://github.com/lukasolson/kibana/assets/25592674/b359ab15-e32c-4106-8e2d-ce3b5446e9e0">